### PR TITLE
Add ability to define custom nexus regions and use in calls to tax_for_order

### DIFF
--- a/lib/taxjar/api/api.rb
+++ b/lib/taxjar/api/api.rb
@@ -13,9 +13,11 @@ module Taxjar
     end
 
     def tax_for_order(options = {})
-      perform_post_with_object("/v2/taxes", 'tax', options, Taxjar::Tax)
+      if requestable_for_nexus?(options)
+        perform_post_with_object("/v2/taxes", 'tax', options, Taxjar::Tax)
+      end
     end
-    
+
     def nexus_regions(options = {})
       perform_get_with_objects("/v2/nexus/regions", 'regions', options, Taxjar::NexusRegion)
     end
@@ -27,9 +29,21 @@ module Taxjar
     def validate(options = {})
       perform_get_with_object("/v2/validation", 'validation', options, Taxjar::Validation)
     end
-    
+
     def summary_rates(options = {})
       perform_get_with_objects("/v2/summary_rates", 'summary_rates', options, Taxjar::SummaryRate)
+    end
+
+    private
+
+    def requestable_for_nexus?(options)
+      return true unless valid_us_order?(options) && custom_nexus_regions
+
+      custom_nexus_regions.include?(options[:to_state])
+    end
+
+    def valid_us_order?(options)
+      options[:to_country] == 'US' && options[:to_state]
     end
   end
 end

--- a/lib/taxjar/client.rb
+++ b/lib/taxjar/client.rb
@@ -17,6 +17,7 @@ module Taxjar
     attr_accessor :api_url
     attr_accessor :headers
     attr_accessor :http_proxy
+    attr_accessor :custom_nexus_regions
 
     def initialize(options = {})
       options.each do |key, value|
@@ -30,6 +31,7 @@ module Taxjar
     end
 
     def set_api_config(key, value)
+      validate_nexus(value) if key == 'custom_nexus_regions'
       instance_variable_set("@#{key}", value)
     end
 
@@ -46,6 +48,12 @@ module Taxjar
       ruby_version = "ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
       openSSL_version = OpenSSL::OPENSSL_LIBRARY_VERSION
       "TaxJar/Ruby (#{platform}; #{ruby_version}; #{openSSL_version}) taxjar-ruby/#{Taxjar::Version}"
+    end
+
+    private
+
+    def validate_nexus(value)
+      raise 'custom_nexus_regions must be an array of 2-character strings' unless value.is_a?(Array) && value.all? { |v| v.is_a?(String) && v.length == 2 }
     end
   end
 end

--- a/spec/taxjar/client_spec.rb
+++ b/spec/taxjar/client_spec.rb
@@ -31,6 +31,18 @@ describe Taxjar::Client do
       client.set_api_config('headers', { 'X-TJ-Expected-Response' => 422 })
       expect(client.headers).to eq({ 'X-TJ-Expected-Response' => 422 })
     end
+
+    it 'sets custom nexus regions when valid format' do
+      client = Taxjar::Client.new(api_key: 'AK')
+      client.set_api_config('custom_nexus_regions', ['AZ', 'PA', 'CA'])
+      expect(client.custom_nexus_regions).to eq(['AZ', 'PA', 'CA'])
+    end
+
+    it 'raises on invalid format of custom nexus regions' do
+      client = Taxjar::Client.new(api_key: 'AK')
+      expect { client.set_api_config('custom_nexus_regions', [123, 'HELLO', nil]) }
+        .to raise_error('custom_nexus_regions must be an array of 2-character strings')
+    end
   end
 
   describe "#get_api_config" do


### PR DESCRIPTION
This PR is an elementary approach to introduce two new pieces of functionality:

1. `Client#set_api_config` accepts and validates a new option, `'custom_nexus_regions'`, that expects an array of 2-character strings.
2. `API#tax_for_order` now uses `custom_nexus_regions`, when present, to only make a request if the params given include a `to_state` that is included in the list of `custom_nexus_regions` and a `to_country` is included that matches `'US'`. For non-US orders or orders without a to_country or to_state param present, the call will still be made as normal.

Although tests have been added, they are also fairly rudimentary, and no full request specs have been made.

It should be noted that in this initial design, some basic assumptions have been made, chiefly that any given values are upper-cased. This would be trivial to correct for, but it is not currently handled here.